### PR TITLE
Updated to use the renamed collection

### DIFF
--- a/automation/ansible/inventory-nearestprime-demo.yml
+++ b/automation/ansible/inventory-nearestprime-demo.yml
@@ -4,21 +4,19 @@ all:
       hosts:
         cloud1:
           ansible_connection: local
-          kubeconfig: "{{ lookup('ansible.builtin.env', 'HOME') }}/.kube/config"
-          namespace: nearestprime-1
-          init:
-            siteName: cloud-1
-            enableServiceSync: 'false'
-          token:
-            type: cert
-          services:
-            nearestprime:
+          skupper_option_kubeconfig: "{{ lookup('ansible.builtin.env', 'HOME') }}/.kube/config"
+          skupper_option_namespace: nearestprime-1
+          skupper_init_site_name: cloud-1
+          skupper_init_enable_service_sync: 'false'
+          skupper_token_type: cert
+          skupper_service_list:
+            - name: nearestprime
               ports:
                 - 8000
               targets:
                 - type: deployment
                   name: nearestprime
-            db:
+            - name: db
               ports:
                 - 5432
     onprem:
@@ -27,31 +25,26 @@ all:
           ansible_connection: local # comment if running against a remote (ssh) machine
           # uncomment below if deploying to a remote machine
           #ansible_host: <remote_ip_addr> # it expects that your user is able to ssh into this IP using its own ssh keys
-          platform: podman
-          init:
-            siteName: onprem-1
-            containerNetwork: nearestprime
-            ingressHosts:
-              - 192.168.124.1
-          links:
+          skupper_option_platform: podman
+          skupper_init_site_name: onprem-1
+          skupper_init_container_network: nearestprime
+          skupper_link_list:
             - host: cloud1
-          services:
-            db:
+          skupper_service_list:
+            - name: db
               ports: [5432]
               targets:
                 - type: "host"
                   name: "db-container"
-              hostIp: "{{ init.ingressHosts[0] }}"
-              hostPorts:
+              host_ports:
                 - 5432:5432
-            load-gen:
+            - name: load-gen
               ports: [8080]
               targets:
                 - type: "host"
                   name: "load-gen-container"
-              hostIp: "{{ init.ingressHosts[0] }}"
-              hostPorts:
+              host_ports:
                 - 8080:8080
-            nearestprime:
+            - name: nearestprime
               ports:
                 - 8000

--- a/automation/ansible/load-gen/start.yml
+++ b/automation/ansible/load-gen/start.yml
@@ -5,5 +5,5 @@
   tasks:
     - name: "Starting load generator"
       ansible.builtin.uri:
-        url: "http://{{ init.ingressHosts[0] }}:8080/set_load/{{ load_gen_size | default(1) }}"
+        url: "http://0.0.0.0:8080/set_load/{{ load_gen_size | default(1) }}"
       

--- a/automation/ansible/load-gen/stop.yml
+++ b/automation/ansible/load-gen/stop.yml
@@ -5,5 +5,5 @@
   tasks:
     - name: "Stopping load generator"
       ansible.builtin.uri:
-        url: "http://{{ init.ingressHosts[0] }}:8080/set_load/0"
+        url: "http://0.0.0.0:8080/set_load/0"
 

--- a/automation/ansible/requirements.yml
+++ b/automation/ansible/requirements.yml
@@ -1,4 +1,4 @@
 collections:
-  - skupper.network
+  - skupper.skupper
   - kubernetes.core
   - containers.podman

--- a/automation/ansible/setup/setup-k8s.yml
+++ b/automation/ansible/setup/setup-k8s.yml
@@ -1,19 +1,19 @@
 ---
 - name: Creating the namespaces
   kubernetes.core.k8s:
-    name: "{{ namespace }}"
+    name: "{{ skupper_option_namespace }}"
     api_version: v1
     kind: Namespace
     state: present
-    kubeconfig: "{{ kubeconfig }}"
+    kubeconfig: "{{ skupper_option_kubeconfig }}"
 - name: Deploying the nearestprime service
   kubernetes.core.k8s:
     name: "nearestprime"
-    namespace: "{{ namespace }}"
+    namespace: "{{ skupper_option_namespace }}"
     api_version: apps/v1
     kind: Deployment
     state: present
-    kubeconfig: "{{ kubeconfig }}"
+    kubeconfig: "{{ skupper_option_kubeconfig }}"
     definition:
       spec:
         selector:

--- a/automation/ansible/setup/setup-podman.yml
+++ b/automation/ansible/setup/setup-podman.yml
@@ -16,7 +16,7 @@
 
 - name: Creating the nearestprime podman network
   containers.podman.podman_network:
-    name: "{{ init.containerNetwork | default('skupper') }}"
+    name: "{{ skupper_init_container_network | default('skupper') }}"
 
 - name: Creating the nearestprime-db container
   containers.podman.podman_container:
@@ -24,7 +24,7 @@
     image: quay.io/fgiorgetti/nearestprime-db
     state: started
     network:
-      - "{{ init.containerNetwork | default('skupper') }}"
+      - "{{ skupper_init_container_network | default('skupper') }}"
 
 - name: Creating the nearestprime-load-gen container
   containers.podman.podman_container:
@@ -32,7 +32,7 @@
     image: quay.io/fgiorgetti/nearestprime-load-gen
     state: started
     network:
-      - "{{ init.containerNetwork | default('skupper') }}"
+      - "{{ skupper_init_container_network | default('skupper') }}"
 
 - name: Creating target directory to install the skupper cli
   ansible.builtin.file:

--- a/automation/ansible/setup/setup-skupper.yml
+++ b/automation/ansible/setup/setup-skupper.yml
@@ -1,3 +1,3 @@
 ---
 - import_role:
-    name: skupper
+    name: skupper_setup

--- a/automation/ansible/setup/setup.yml
+++ b/automation/ansible/setup/setup.yml
@@ -7,11 +7,11 @@
 - hosts: onprem
   collections:
     - containers.podman
-    - skupper.network
+    - skupper.skupper
   tasks:
   - ansible.builtin.include_tasks: setup-podman.yml
 - hosts: all
   collections:
-    - skupper.network
+    - skupper.skupper
   tasks:
   - ansible.builtin.include_tasks: setup-skupper.yml

--- a/automation/ansible/teardown/teardown-k8s.yml
+++ b/automation/ansible/teardown/teardown-k8s.yml
@@ -1,8 +1,8 @@
 ---
 - name: Deleting the namespace
   kubernetes.core.k8s:
-    name: "{{ namespace }}"
+    name: "{{ skupper_option_namespace }}"
     api_version: v1
     kind: Namespace
     state: absent
-    kubeconfig: "{{ kubeconfig }}"
+    kubeconfig: "{{ skupper_option_kubeconfig }}"

--- a/automation/ansible/teardown/teardown-podman.yml
+++ b/automation/ansible/teardown/teardown-podman.yml
@@ -5,7 +5,7 @@
     image: quay.io/fgiorgetti/nearestprime-db
     state: absent
     network:
-      - "{{ init.containerNetwork | default('skupper') }}"
+      - "{{ skupper_init_container_network | default('skupper') }}"
 
 - name: Deleting the nearestprime-load-gen container
   containers.podman.podman_container:
@@ -13,9 +13,9 @@
     image: quay.io/fgiorgetti/nearestprime-load-gen
     state: absent
     network:
-      - "{{ init.containerNetwork | default('skupper') }}"
+      - "{{ skupper_init_container_network | default('skupper') }}"
 
 - name: Deleting the nearestprime podman network
   containers.podman.podman_network:
-    name: "{{ init.containerNetwork | default('skupper') }}"
+    name: "{{ skupper_init_container_network | default('skupper') }}"
     state: absent

--- a/automation/ansible/teardown/teardown-skupper.yml
+++ b/automation/ansible/teardown/teardown-skupper.yml
@@ -1,4 +1,4 @@
 ---
 - include_role:
-    name: skupper_delete
+    name: skupper_teardown
     apply: { ignore_errors: true }

--- a/automation/ansible/teardown/teardown.yml
+++ b/automation/ansible/teardown/teardown.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   collections:
-    - skupper.network
+    - skupper.skupper
   tasks:
   - ansible.builtin.include_tasks: teardown-skupper.yml
 - hosts: cloud


### PR DESCRIPTION
* Updates ansible automation to use the new collection skupper.skupper
* Role variables in this new collection are properly following ansible conventions
* A specific ingress host IP is no longer needed as now it uses 0.0.0.0